### PR TITLE
Use Erlang's and Elixir's more complete log levels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,28 +66,6 @@ jobs:
       - run: mix deps.get
       - run: mix test
 
-  build_elixir_1_10_otp_23:
-    docker:
-      - image: hexpm/elixir:1.10.4-erlang-23.3.4-alpine-3.13.3
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_hex_rebar
-      - <<: *install_system_deps
-      - run: mix deps.get
-      - run: mix test
-
-  build_elixir_1_9_otp_22:
-    docker:
-      - image: hexpm/elixir:1.9.4-erlang-22.3.4.18-alpine-3.13.3
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_hex_rebar
-      - <<: *install_system_deps
-      - run: mix deps.get
-      - run: mix test
-
 workflows:
   version: 2
   build_test:
@@ -95,5 +73,3 @@ workflows:
       - build_elixir_1_13_otp_24
       - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23
-      - build_elixir_1_10_otp_23
-      - build_elixir_1_9_otp_22

--- a/lib/nerves_logging/kmsg_tailer.ex
+++ b/lib/nerves_logging/kmsg_tailer.ex
@@ -46,6 +46,8 @@ defmodule NervesLogging.KmsgTailer do
     {:noreply, %{state | buffer: ""}}
   end
 
+  def handle_info(_, state), do: {:noreply, state}
+
   defp handle_message(raw_entry) do
     case KmsgParser.parse(raw_entry) do
       {:ok, %{facility: facility, severity: severity, message: message}} ->

--- a/lib/nerves_logging/syslog_parser.ex
+++ b/lib/nerves_logging/syslog_parser.ex
@@ -4,7 +4,7 @@ defmodule NervesLogging.SyslogParser do
   """
 
   @type severity ::
-          :alert | :critical | :debug | :emergency | :error | :informational | :notice | :warning
+          :alert | :critical | :debug | :emergency | :error | :info | :notice | :warning
 
   @type facility ::
           :kernel
@@ -117,17 +117,6 @@ defmodule NervesLogging.SyslogParser do
   defp severity_name(3), do: :error
   defp severity_name(4), do: :warning
   defp severity_name(5), do: :notice
-  defp severity_name(6), do: :informational
+  defp severity_name(6), do: :info
   defp severity_name(7), do: :debug
-
-  @doc """
-  Convert severity to an Elixir logger level
-  """
-  @spec severity_to_logger(severity()) :: Logger.level()
-  def severity_to_logger(severity) when severity in [:emergency, :alert, :critical, :error],
-    do: :error
-
-  def severity_to_logger(severity) when severity == :warning, do: :warn
-  def severity_to_logger(severity) when severity in [:notice, :informational], do: :info
-  def severity_to_logger(severity) when severity == :debug, do: :debug
 end

--- a/lib/nerves_logging/syslog_tailer.ex
+++ b/lib/nerves_logging/syslog_tailer.ex
@@ -53,4 +53,6 @@ defmodule NervesLogging.SyslogTailer do
 
     {:noreply, log_port}
   end
+
+  def handle_info(_, state), do: {:noreply, state}
 end

--- a/lib/nerves_logging/syslog_tailer.ex
+++ b/lib/nerves_logging/syslog_tailer.ex
@@ -37,14 +37,11 @@ defmodule NervesLogging.SyslogTailer do
   def handle_info({:udp, log_port, _, 0, raw_entry}, log_port) do
     case SyslogParser.parse(raw_entry) do
       {:ok, %{facility: facility, severity: severity, message: message}} ->
-        level = SyslogParser.severity_to_logger(severity)
-
         Logger.bare_log(
-          level,
+          severity,
           message,
           module: __MODULE__,
-          facility: facility,
-          severity: severity
+          facility: facility
         )
 
       _ ->

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule NervesLogging.MixProject do
     [
       app: :nerves_logging,
       version: @version,
-      elixir: "~> 1.9",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       build_embedded: true,
       compilers: [:elixir_make | Mix.compilers()],

--- a/test/nerves_logging/kmsg_parser_test.exs
+++ b/test/nerves_logging/kmsg_parser_test.exs
@@ -36,7 +36,7 @@ defmodule NervesLogging.KmsgParserTest do
               message:
                 "oom_reaper: reaped process 14910 (code), now anon-rss:0kB, file-rss:0kB, shmem-rss:0kB",
               facility: :kernel,
-              severity: :informational,
+              severity: :info,
               sequence: 7004,
               timestamp: 192_203_028_735,
               flags: []

--- a/test/nerves_logging/syslog_parser_test.exs
+++ b/test/nerves_logging/syslog_parser_test.exs
@@ -11,7 +11,7 @@ defmodule NervesLogging.SyslogParserTest do
     assert {:ok, %{facility: :user_level, severity: :notice, message: "Test Message"}} ==
              SyslogParser.parse("<13>Test Message")
 
-    assert {:ok, %{facility: :local2, severity: :informational, message: "Test Message"}} ==
+    assert {:ok, %{facility: :local2, severity: :info, message: "Test Message"}} ==
              SyslogParser.parse("<150>Test Message")
 
     assert {:ok, %{facility: :local7, severity: :debug, message: "Test Message"}} ==
@@ -32,21 +32,7 @@ defmodule NervesLogging.SyslogParserTest do
   test "decodes priority" do
     assert {:ok, :kernel, :emergency} == SyslogParser.decode_priority(0)
     assert {:ok, :user_level, :notice} == SyslogParser.decode_priority(13)
-    assert {:ok, :local2, :informational} == SyslogParser.decode_priority(150)
+    assert {:ok, :local2, :info} == SyslogParser.decode_priority(150)
     assert {:ok, :local7, :debug} == SyslogParser.decode_priority(191)
-  end
-
-  test "converts severity to logger levels" do
-    assert :error == SyslogParser.severity_to_logger(:emergency)
-    assert :error == SyslogParser.severity_to_logger(:alert)
-    assert :error == SyslogParser.severity_to_logger(:critical)
-    assert :error == SyslogParser.severity_to_logger(:error)
-
-    assert :warn == SyslogParser.severity_to_logger(:warning)
-
-    assert :info == SyslogParser.severity_to_logger(:notice)
-    assert :info == SyslogParser.severity_to_logger(:informational)
-
-    assert :debug == SyslogParser.severity_to_logger(:debug)
   end
 end


### PR DESCRIPTION
Starting with Elixir 1.11, Elixir started using the full list of log
levels provided by Erlang's new logger service. This commit the
following:

1. Remove code to convert syslog severity to Elixir log levels
2. Rename `:informational` to `:info` to match Erlang and Elixir
3. Remove the `:severity` field from the log message since it's
   redundant now.

This is technically a breaking change for any code that used the
`:severify` field in the log message, but I don't think there are any
cases in the wild that do that. I'd expect most code to use the log
level and after this commit, it will match the reported level.
