### PR TITLE
Support OTP 25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ install_system_deps: &install_system_deps
         apk add build-base
 
 jobs:
-  build_elixir_1_13_otp_24:
+  build_elixir_1_13_otp_25:
     docker:
-      - image: hexpm/elixir:1.13.3-erlang-24.2.1-alpine-3.15.0
+      - image: hexpm/elixir:1.13.4-erlang-25.0-alpine-3.15.4
     <<: *defaults
     steps:
       - checkout
@@ -44,9 +44,20 @@ jobs:
             - _build
             - deps
 
+  build_elixir_1_13_otp_24:
+    docker:
+      - image: hexpm/elixir:1.13.4-erlang-24.3.4-alpine-3.15.3
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_hex_rebar
+      - <<: *install_system_deps
+      - run: mix deps.get
+      - run: mix test
+
   build_elixir_1_12_otp_24:
     docker:
-      - image: hexpm/elixir:1.12.3-erlang-24.1.2-alpine-3.14.2
+      - image: hexpm/elixir:1.12.3-erlang-24.3.4-alpine-3.15.3
     <<: *defaults
     steps:
       - checkout
@@ -57,7 +68,7 @@ jobs:
 
   build_elixir_1_11_otp_23:
     docker:
-      - image: hexpm/elixir:1.11.4-erlang-23.3.4-alpine-3.13.3
+      - image: hexpm/elixir:1.11.4-erlang-23.3.4.13-alpine-3.15.3
     <<: *defaults
     steps:
       - checkout
@@ -70,6 +81,7 @@ workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_13_otp_25
       - build_elixir_1_13_otp_24
       - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23

--- a/mix.exs
+++ b/mix.exs
@@ -72,7 +72,7 @@ defmodule NervesLogging.MixProject do
 
   defp dialyzer() do
     [
-      flags: [:race_conditions, :unmatched_returns, :error_handling, :underspecs]
+      flags: [:missing_return, :extra_return, :unmatched_returns, :error_handling, :underspecs]
     ]
   end
 end


### PR DESCRIPTION
* remove deprecated `:race_conditions` dialyzer option
* Add new `:missing_return` and `:extra_return` dialyzer options
* Update Elixir/Erlang CI versions