### PR TITLE
Don't crash if loggers don't have permission

### DIFF
--- a/lib/nerves_logging/application.ex
+++ b/lib/nerves_logging/application.ex
@@ -5,16 +5,7 @@ defmodule NervesLogging.Application do
 
   @impl Application
   def start(_type, _args) do
-    # Don't automatically start loggers if they'll fail
-    children =
-      if File.exists?("/dev/kmsg") do
-        [
-          NervesLogging.KmsgTailer,
-          NervesLogging.SyslogTailer
-        ]
-      else
-        []
-      end
+    children = [NervesLogging.KmsgTailer, NervesLogging.SyslogTailer]
 
     opts = [strategy: :one_for_one, name: NervesLogging.Supervisor]
     Supervisor.start_link(children, opts)


### PR DESCRIPTION
Instead log a message and let the system carry on. Crashing the logger
can make the system unusable when it could work without logging. While
it's not great, the alternative is looking worse.
