### PR TITLE
Convert to a library

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ NervesLogging forwards log messages from the Linux kernel and syslog to the
 Elixir logger. It's used with Nerves so that all log messages pass through one
 place.
 
-There's no configuration. NervesLogging starts automatically.
-
 Messages logged by NervesLogging copy the "Syslog" severity directly to the
 Logger level. This means that if the kernel's level is "Error", the Elixir level
 will be `:error`. Since Elixir 1.11 and later have the same log levels as
@@ -19,6 +17,19 @@ The Syslog facility is passed via log metadata.
 See the [Elixir Logger documentation](https://hexdocs.pm/logger/Logger.html) for
 reducing what's logged if the system logs become too noisy. For example, try
 `Logger.put_application_level(:nerves_logging, :error)`.
+
+## Using
+
+There's no configuration. Add the following to a supervision tree to capture the
+logs:
+
+```elixir
+    [NervesLogging.KmsgTailer, NervesLogging.SyslogTailer]
+```
+
+If you're using Nerves, you don't need to do this.
+[Nerves.Runtime](https://github.com/nerves-project/nerves_runtime) adds these to
+its supervision tree.
 
 ## License
 

--- a/lib/nerves_logging/kmsg_tailer.ex
+++ b/lib/nerves_logging/kmsg_tailer.ex
@@ -20,22 +20,17 @@ defmodule NervesLogging.KmsgTailer do
 
   @impl GenServer
   def init(_args) do
-    if File.exists?("/dev/kmsg") do
-      executable = Application.app_dir(:nerves_logging, ["priv", "kmsg_tailer"])
+    executable = Application.app_dir(:nerves_logging, ["priv", "kmsg_tailer"])
 
-      port =
-        Port.open({:spawn_executable, executable}, [
-          {:line, 1024},
-          :use_stdio,
-          :binary,
-          :exit_status
-        ])
+    port =
+      Port.open({:spawn_executable, executable}, [
+        {:line, 1024},
+        :use_stdio,
+        :binary,
+        :exit_status
+      ])
 
-      {:ok, %{port: port, buffer: ""}}
-    else
-      Logger.error("nerves_logger: not starting kmsg server since /dev/kmsg doesn't exist")
-      :ignore
-    end
+    {:ok, %{port: port, buffer: ""}}
   end
 
   @impl GenServer

--- a/mix.exs
+++ b/mix.exs
@@ -26,8 +26,7 @@ defmodule NervesLogging.MixProject do
 
   def application do
     [
-      extra_applications: [:logger],
-      mod: {NervesLogging.Application, []}
+      extra_applications: [:logger]
     ]
   end
 


### PR DESCRIPTION
This is a backwards incompatible change.

Instead of starting up the kmsg and syslog tailers automatically. They
now must be linked into a supervision tree. This means that
NervesLogging no longer needs to figure out whether it's running on a
device or not. That simplifies the code here and makes it possible for
the code that uses it to decide.
