### PR TITLE
Set the application field for kmsg/syslog entries

### DIFF
--- a/lib/nerves_logging/kmsg_tailer.ex
+++ b/lib/nerves_logging/kmsg_tailer.ex
@@ -58,6 +58,7 @@ defmodule NervesLogging.KmsgTailer do
         Logger.bare_log(
           severity,
           message,
+          application: :"$kmsg",
           module: __MODULE__,
           facility: facility
         )

--- a/lib/nerves_logging/syslog_tailer.ex
+++ b/lib/nerves_logging/syslog_tailer.ex
@@ -48,6 +48,7 @@ defmodule NervesLogging.SyslogTailer do
         Logger.bare_log(
           severity,
           message,
+          application: :"$syslog",
           module: __MODULE__,
           facility: facility
         )


### PR DESCRIPTION
The values `$kmsg` and `$syslog` are used to avoid any naming conflicts
with real Elixir/Erlang libraries.

This is most visible when using `RingLogger.viewer` since there's an application column and it had previously been showing `nil` for both kmsg and syslog log entries.
