### PR TITLE
Add log_level options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,34 @@ reducing what's logged if the system logs become too noisy. For example, try
 
 ## Using
 
-There's no configuration. Add the following to a supervision tree to capture the
-logs:
+NervesLogging can be started with or without configuration. The only available options currently are the `log_level` for `NervesLogging.KmsgTailer` and for `log_level` for `NervesLogging.SyslogTailer`. Both are optional
+
+The options for `log_level` are one of: [:emergency, :alert, :critical, :error, :warning, :notice, :informational, :debug]. Default is `:error`.
+
+Configure with:
+```elixir
+config :nerves_logging, :syslog,
+  log_level: :error
+
+config :nerves_logging, :kmsg,
+  log_level: :error
+```
+
+Add one of the following to a supervision tree to capture the
+logs (note, the configuration options above will NOT be applied when adding to a custom supervison tree like in the code snippets below):
 
 ```elixir
     [NervesLogging.KmsgTailer, NervesLogging.SyslogTailer]
 ```
 
+```elixir
+    # add with options
+    [{NervesLogging.KmsgTailer, [log_level: :error]}, {NervesLogging.SyslogTailer, [log_level: :error]}]
+```
+
 If you're using Nerves, you don't need to do this.
 [Nerves.Runtime](https://github.com/nerves-project/nerves_runtime) adds these to
-its supervision tree.
+its supervision tree. The configuration options can be applied using this method.
 
 ## License
 

--- a/lib/nerves_logging/application.ex
+++ b/lib/nerves_logging/application.ex
@@ -9,7 +9,13 @@ defmodule NervesLogging.Application do
 
   @impl Application
   def start(_type, _args) do
-    children = [NervesLogging.KmsgTailer, NervesLogging.SyslogTailer]
+    syslog_opts = Application.get_env(:nerves_logging, :syslog, [])
+    kmsg_opts = Application.get_env(:nerves_logging, :kmsg, [])
+
+    children = [
+      {NervesLogging.KmsgTailer, syslog_opts},
+      {NervesLogging.SyslogTailer, kmsg_opts}
+    ]
 
     opts = [strategy: :one_for_one, name: NervesLogging.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/nerves_logging/syslog_parser.ex
+++ b/lib/nerves_logging/syslog_parser.ex
@@ -91,6 +91,22 @@ defmodule NervesLogging.SyslogParser do
     {:error, :parse_error}
   end
 
+  @doc """
+  Validate the given log level
+  """
+  @spec validate_log_level(any()) :: atom()
+  def validate_log_level(level) when is_atom(level) do
+    if level in Logger.levels() do
+      level
+    else
+      :error
+    end
+  end
+
+  def validate_log_level(_) do
+    :error
+  end
+
   defp facility_name(0), do: :kernel
   defp facility_name(1), do: :user_level
   defp facility_name(2), do: :mail

--- a/lib/nerves_logging/syslog_tailer.ex
+++ b/lib/nerves_logging/syslog_tailer.ex
@@ -17,15 +17,39 @@ defmodule NervesLogging.SyslogTailer do
   @syslog_path "/dev/log"
 
   @doc """
+  Return current `log_level`
+  """
+  @spec get_log_level() :: atom()
+  def get_log_level() do
+    GenServer.call(__MODULE__, :get_log_level)
+  end
+
+  @doc """
+  Set current `log_level` to one of `Logger.levels()`
+  """
+  @spec set_log_level(any()) :: :ok | {:error, :bad_level}
+  def set_log_level(level) when is_atom(level) do
+    if level in Logger.levels() do
+      GenServer.cast(__MODULE__, {:set_log_level, level})
+    else
+      {:error, :bad_level}
+    end
+  end
+
+  def set_log_level(_) do
+    {:error, :bad_level}
+  end
+
+  @doc """
   Start the local syslog GenServer.
   """
   @spec start_link(any()) :: GenServer.on_start()
-  def start_link(_args) do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
   @impl GenServer
-  def init(_args) do
+  def init(opts) do
     # Blindly try to remove an old file just in case it exists from a previous run
     _ = File.rm(@syslog_path)
 
@@ -33,8 +57,9 @@ defmodule NervesLogging.SyslogTailer do
       {:ok, log_port} ->
         # All processes should be able to log messages
         File.chmod!(@syslog_path, 0o666)
+        log_level = Keyword.get(opts, :log_level) |> SyslogParser.validate_log_level()
 
-        {:ok, log_port}
+        {:ok, %{log_port: log_port, log_level: log_level}}
 
       {:error, reason} ->
         Logger.error("nerves_logger: not starting syslog server due to #{inspect(reason)}")
@@ -43,16 +68,21 @@ defmodule NervesLogging.SyslogTailer do
   end
 
   @impl GenServer
-  def handle_info({:udp, log_port, _, 0, raw_entry}, log_port) do
+  def handle_info(
+        {:udp, log_port, _, 0, raw_entry},
+        state = %{log_port: log_port, log_level: log_level}
+      ) do
     case SyslogParser.parse(raw_entry) do
       {:ok, %{facility: facility, severity: severity, message: message}} ->
-        Logger.bare_log(
-          severity,
-          message,
-          application: :"$syslog",
-          module: __MODULE__,
-          facility: facility
-        )
+        if Logger.compare_levels(severity, log_level) in [:gt, :eq] do
+          Logger.bare_log(
+            severity,
+            message,
+            application: :"$syslog",
+            module: __MODULE__,
+            facility: facility
+          )
+        end
 
       _ ->
         # This is unlikely to ever happen, but if a message was somehow
@@ -61,8 +91,18 @@ defmodule NervesLogging.SyslogTailer do
         Logger.warning("Malformed syslog report: #{inspect(raw_entry)}")
     end
 
-    {:noreply, log_port}
+    {:noreply, state}
   end
 
   def handle_info(_, state), do: {:noreply, state}
+
+  @impl GenServer
+  def handle_call(:get_log_level, _from, state = %{log_level: log_level}) do
+    {:reply, log_level, state}
+  end
+
+  @impl GenServer
+  def handle_cast({:set_log_level, level}, state) do
+    {:noreply, Map.put(state, :log_level, level)}
+  end
 end


### PR DESCRIPTION
Allows the developer to configure the level they want to receive logs at for both syslog and kmsg.

The Logger.put_application_level(:nerves_logging, :error) as mentioned in the README does not work as intended, where I have seen several :info level kmsgs still being logged.