### PR TITLE
Fix logging so it was actually adjustable

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -10,7 +10,8 @@
         {Credo.Check.Readability.LargeNumbers, only_greater_than: 86400},
         {Credo.Check.Readability.ParenthesesOnZeroArityDefs, parens: true},
         {Credo.Check.Readability.Specs, tags: []},
-        {Credo.Check.Readability.StrictModuleLayout, tags: []}
+        {Credo.Check.Readability.StrictModuleLayout, tags: []},
+        {Credo.Check.Warning.MissedMetadataKeyInLoggerConfig, false}
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -17,8 +17,18 @@ Syslog, this mapping is 1:1.
 The Syslog facility is passed via log metadata.
 
 See the [Elixir Logger documentation](https://hexdocs.pm/logger/Logger.html) for
-reducing what's logged if the system logs become too noisy. For example, try
-`Logger.put_application_level(:nerves_logging, :error)`.
+reducing what's logged if the system logs become too noisy. Some examples:
+
+```elixir
+# Reduce logging for both syslog and kernel logs
+Logger.put_application_level(:nerves_logging, :error)
+
+# Adjust logging for kernel logs
+Logger.put_module_level(NervesLogging.KmsgTailer, :info)
+
+# Adjust logging for syslog logs
+Logger.put_module_level(NervesLogging.SyslogTailer, :info)
+```
 
 ## Using
 

--- a/lib/nerves_logging/kmsg_tailer.ex
+++ b/lib/nerves_logging/kmsg_tailer.ex
@@ -56,13 +56,7 @@ defmodule NervesLogging.KmsgTailer do
   defp handle_message(raw_entry) do
     case KmsgParser.parse(raw_entry) do
       {:ok, %{facility: facility, severity: severity, message: message}} ->
-        Logger.bare_log(
-          severity,
-          message,
-          application: :"$kmsg",
-          module: __MODULE__,
-          facility: facility
-        )
+        Logger.log(severity, message, application: :"$kmsg", facility: facility)
 
       _ ->
         # We don't handle continuations and multi-line kmsg logs.

--- a/lib/nerves_logging/syslog_tailer.ex
+++ b/lib/nerves_logging/syslog_tailer.ex
@@ -46,13 +46,7 @@ defmodule NervesLogging.SyslogTailer do
   def handle_info({:udp, log_port, _, 0, raw_entry}, log_port) do
     case SyslogParser.parse(raw_entry) do
       {:ok, %{facility: facility, severity: severity, message: message}} ->
-        Logger.bare_log(
-          severity,
-          message,
-          application: :"$syslog",
-          module: __MODULE__,
-          facility: facility
-        )
+        Logger.log(severity, message, application: :"$syslog", facility: facility)
 
       _ ->
         # This is unlikely to ever happen, but if a message was somehow


### PR DESCRIPTION
There are a few ways of adjusting logging levels with the Erlang logger,
but the ones in the README.md actually didn't work. The problems were that
the existing code was calling `Logger.bare_log` and not setting the
`:mfa` metadata to make the caller identifiable AND `Logger.bare_log`
doesn't do any checking of `:mfa` so filtering at the Logger call
doesn't work.

`Logger.log/3` makes this easy since it fills in `:mfa` automatically
and filters on the calling module before forwarding the message.
