### PR TITLE
Bump supported versions of Elixir; refresh CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,16 @@
 version: 2.1
 
 latest: &latest
-  pattern: "^1.15.*-erlang-26.*$"
+  pattern: "^1.18.*-erlang-27.*$"
 
 tags: &tags
   [
-    1.15.7-erlang-26.1.2-alpine-3.18.4,
-    1.14.5-erlang-25.3.2-alpine-3.18.0,
-    1.13.4-erlang-25.3.2-alpine-3.18.0,
-    1.12.3-erlang-24.3.4.11-alpine-3.18.0,
-    1.11.4-erlang-23.3.4.13-alpine-3.15.3
+    1.18.3-erlang-27.3-alpine-3.21.3,
+    1.17.3-erlang-27.2-alpine-3.20.3,
+    1.16.3-erlang-26.2.5-alpine-3.19.1,
+    1.15.7-erlang-26.2.4-alpine-3.18.6,
+    1.14.5-erlang-25.3.2.11-alpine-3.17.7,
+    1.13.4-erlang-24.3.4.17-alpine-3.16.9
   ]
 
 jobs:
@@ -43,6 +44,8 @@ jobs:
           keys:
             - v1-mix-cache-<< parameters.tag >>-{{ checksum "mix.lock" }}
       - run: mix deps.get
+      - run: mix compile --warnings-as-errors
+      - run: MIX_ENV=test mix compile --warnings-as-errors
       - run: mix test
       - when:
           condition:
@@ -62,7 +65,7 @@ jobs:
 
   automerge:
     docker:
-        - image: alpine:3.18.4
+        - image: alpine:3.21.3
     steps:
       - run:
           name: Install GitHub CLI
@@ -81,12 +84,18 @@ jobs:
 workflows:
   checks:
     jobs:
-      - check-license
+      - check-license:
+          filters:
+            tags:
+              only: /.*/
       - build-test:
           name: << matrix.tag >>
           matrix:
             parameters:
               tag: *tags
+          filters:
+            tags:
+              only: /.*/
       - automerge:
           requires: *tags
           context: org-global

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule NervesLogging.MixProject do
     [
       app: :nerves_logging,
       version: @version,
-      elixir: "~> 1.11",
+      elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],


### PR DESCRIPTION
This drops Elixir 1.12 and earlier which have been long since dropped by
almost all other Nerves libraries. They may or may not be broken since
they're not really tested. This pulls in a couple other snippets from
similar CircleCI configs.
