### PR TITLE
Fix docs on how to use and privatize API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,9 @@ Logger.put_module_level(NervesLogging.SyslogTailer, :info)
 
 ## Using
 
-There's no configuration. Add the following to a supervision tree to capture the
-logs:
-
-```elixir
-    [NervesLogging.KmsgTailer, NervesLogging.SyslogTailer]
-```
-
-If you're using Nerves, you don't need to do this.
-[Nerves.Runtime](https://github.com/nerves-project/nerves_runtime) adds these to
-its supervision tree.
+There's no configuration. If you're using Nerves, you should get this
+application by default since it's pulled in by
+[Nerves.Runtime](https://github.com/nerves-project/nerves_runtime).
 
 ## License
 

--- a/lib/nerves_logging/kmsg_parser.ex
+++ b/lib/nerves_logging/kmsg_parser.ex
@@ -4,9 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule NervesLogging.KmsgParser do
-  @moduledoc """
-  Functions for parsing kmsg strings
-  """
+  @moduledoc false
 
   alias NervesLogging.SyslogParser
 

--- a/lib/nerves_logging/kmsg_tailer.ex
+++ b/lib/nerves_logging/kmsg_tailer.ex
@@ -4,11 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule NervesLogging.KmsgTailer do
-  @moduledoc """
-  Collects operating system-level messages from `/proc/kmsg`,
-  forwarding them to `Logger` with an appropriate level to match the syslog
-  priority parsed out of the message.
-  """
+  @moduledoc false
+
+  # Collects operating system-level messages from `/proc/kmsg`,
+  # forwarding them to `Logger` with an appropriate level to match the syslog
+  # priority parsed out of the message.
 
   use GenServer
 

--- a/lib/nerves_logging/syslog_parser.ex
+++ b/lib/nerves_logging/syslog_parser.ex
@@ -4,9 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule NervesLogging.SyslogParser do
-  @moduledoc """
-  Functions for parsing syslog strings
-  """
+  @moduledoc false
 
   @type severity ::
           :alert | :critical | :debug | :emergency | :error | :info | :notice | :warning

--- a/lib/nerves_logging/syslog_tailer.ex
+++ b/lib/nerves_logging/syslog_tailer.ex
@@ -4,10 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule NervesLogging.SyslogTailer do
-  @moduledoc """
-  This GenServer routes syslog messages from C-based applications and libraries through
-  the Elixir Logger for collection.
-  """
+  @moduledoc false
+  # This GenServer routes syslog messages from C-based applications and libraries through
+  # the Elixir Logger for collection.
 
   use GenServer
 


### PR DESCRIPTION
The API never was intented to be public. This makes it more clear and
reduces clutter when you actually read the hexdocs.
