### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # NervesLogging
 
 [![Hex version](https://img.shields.io/hexpm/v/nerves_logging.svg "Hex version")](https://hex.pm/packages/nerves_logging)
-[![API docs](https://img.shields.io/hexpm/v/nerves_logging.svg?label=hexdocs "API docs")](https://hexdocs.pm/nerves_logging/NervesLogging.html)
+[![API docs](https://img.shields.io/hexpm/v/nerves_logging.svg?label=hexdocs "API docs")](https://nerves-logging.hexdocs.pm/NervesLogging.html)
 [![CircleCI](https://circleci.com/gh/nerves-project/nerves_logging.svg?style=svg)](https://circleci.com/gh/nerves-project/nerves_logging)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-project/nerves_logging)](https://api.reuse.software/info/github.com/nerves-project/nerves_logging)
 
@@ -24,7 +24,7 @@ NervesLogging adds the following metadata to the log messages:
 * `:facility` - the facility of the log message
 * `:application` - either `:$kmsg` or `:$syslog`
 
-See the [Elixir Logger documentation](https://hexdocs.pm/logger/Logger.html) for
+See the [Elixir Logger documentation](https://logger.hexdocs.pm/Logger.html) for
 reducing what's logged if the system logs become too noisy. Some examples:
 
 ```elixir

--- a/lib/nerves_logging.ex
+++ b/lib/nerves_logging.ex
@@ -11,7 +11,7 @@ defmodule NervesLogging do
   * `:facility` - the facility of the log message
   * `:application` - either `:$kmsg` or `:$syslog`
 
-  See the [Elixir Logger documentation](https://hexdocs.pm/logger/Logger.html) for
+  See the [Elixir Logger documentation](https://logger.hexdocs.pm/Logger.html) for
   reducing what's logged if the system logs become too noisy. Some examples:
 
   ```elixir

--- a/mix.exs
+++ b/mix.exs
@@ -71,7 +71,7 @@ defmodule NervesLogging.MixProject do
       ],
       licenses: ["Apache-2.0"],
       links: %{
-        "Changelog" => "https://hexdocs.pm/nerves_logging/changelog.html",
+        "Changelog" => "https://nerves-logging.hexdocs.pm/changelog.html",
         "GitHub" => @source_url,
         "REUSE Compliance" =>
           "https://api.reuse.software/info/github.com/nerves-project/nerves_logging"


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://nerves-logging.hexdocs.pm/NervesLogging.html): Status 404
❌ Verification failed for https://logger.hexdocs.pm/Logger.html): Status 404
⚠️ Verification finished: 1 success, 2 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>